### PR TITLE
Change <silent> to :silent

### DIFF
--- a/plugin/deleft.vim
+++ b/plugin/deleft.vim
@@ -23,7 +23,7 @@ endif
 
 command! Deleft call s:Deleft()
 if g:deleft_mapping != ''
-  exe 'nnoremap <silent> '.g:deleft_mapping.' :call <SID>Deleft()<cr>'
+  exe 'nnoremap <silent> '.g:deleft_mapping.' :silent Deleft<cr>'
 endif
 
 function! s:Deleft()


### PR DESCRIPTION
This may be because of my configuration or because I use Neovim, in which case sorry for the spam.  This plugin looked really cool and I installed it right away.  When I use it on Ruby code, output at the bottom interrupts me until I press enter.

<img width="1020" alt="screen shot 2017-06-06 at 11 23 50 am" src="https://user-images.githubusercontent.com/1154307/26837208-de1b305c-4aaa-11e7-9c35-c6a8b64bc291.png">

I added `:silent` to the default mapping and that fixed the issue.

<img width="1020" alt="screen shot 2017-06-06 at 11 24 22 am" src="https://user-images.githubusercontent.com/1154307/26837219-e2d04a38-4aaa-11e7-841c-1a30ab66cb4e.png">
